### PR TITLE
Fix typo in drivers_controller.rb

### DIFF
--- a/app/controllers/drivers_controller.rb
+++ b/app/controllers/drivers_controller.rb
@@ -1,4 +1,4 @@
-class DriverController < ApplicationController
+class DriversController < ApplicationController
   def index
     @drivers = Driver.all
   end


### PR DESCRIPTION
Fix a typo in the drivers_controller that was causing an error
